### PR TITLE
corrected gamedir volume mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ mkdir gamedir && echo 'echo "Executing custom server.cfg"' > gamedir/server.cfg
 Add your settings to the `server.cfg` and mount the directory as volume by running:
 
 ```
-docker run -it --rm -d -p27015:27015 -p27015:27015/udp -v gamedir:/gamedir spezifanta/hldm
+docker run -it --rm -d -p27015:27015 -p27015:27015/udp -v gamedir:/tmp/gamedir spezifanta/hldm
 ```
 
 You should see `Executing custom server.cfg` in the server log when starting the server.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,6 @@ services:
     #   - '27015:27015/udp'
     #   - '26900:26900/udp'
     volumes:
-      - './gamedir:/gamedir'
+      - './gamedir:/tmp/gamedir'
     command: +maxplayers 12 +map crossfire +rcon_password "supersecret" +log on +logaddress 0.0.0.0 27500 +sys_ticrate 1000 -pingboost 2
     network_mode: 'host'


### PR DESCRIPTION
Now the volume mounts where docker/entrypoint.sh expects to find it, namely /tmp/gamedir.